### PR TITLE
Unnecessary symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
     `rvm gemset use global`
 
-    `$ echo "gem: --no-document" >> ~/.gemrc`
+    `echo "gem: --no-document" >> ~/.gemrc`
 
     `gem install bundler`
 


### PR DESCRIPTION
The dollar sign was misleading especially when newbies just copy paste and find the code doesn't work in the terminal. Thus removed it.